### PR TITLE
Check for custom description lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -117,11 +117,6 @@ function gotoNextLine(){
     currentLine = lines[++currentLineNumber];
 }
 
-function getNextLine(){
-    let nextLineNumber = currentLineNumber;
-    return lines[++nextLineNumber];
-}
-
 let tokenSource = null;
 let tokenSourceLength = 0;
 let tokenStart = 0;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -64,14 +64,8 @@ function parser(filename, fileInput){
     // Check for custom description lines and last #
     if(currentLine.startsWith('#')){
         do {
-            if(getNextLine().startsWith('#')){
-                gotoNextLine();
-            } else {
-                break;
-            }
+            gotoNextLine();
         } while(currentLine.startsWith('#'));
-        
-        gotoNextLine();
     } else {
         throw Error('Missing #');
     }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -43,7 +43,7 @@ function parser(filename, fileInput){
 
     // Check for Name:
     if(currentLine.startsWith('Name: ')){
-        palette.name = currentLine.substr('Name: '.length);
+        palette.name = currentLine.substr('Name: '.length).trim();
         gotoNextLine();
 
         // Columns: x
@@ -60,12 +60,21 @@ function parser(filename, fileInput){
     } else {
         palette.name = filename;
     }
-
-    // At this point we should be by the # so check
-    if(currentLine.trim() != '#'){
+    
+    // Check for custom description lines and last #
+    if(currentLine.startsWith('#')){
+        do {
+            if(getNextLine().startsWith('#')){
+                gotoNextLine();
+            } else {
+                break;
+            }
+        } while(currentLine.startsWith('#'));
+        
+        gotoNextLine();
+    } else {
         throw Error('Missing #');
     }
-    gotoNextLine();
 
     const totalLines = lines.length;
     let lineValues = null;
@@ -112,6 +121,11 @@ function parser(filename, fileInput){
 
 function gotoNextLine(){
     currentLine = lines[++currentLineNumber];
+}
+
+function getNextLine(){
+    let nextLineNumber = currentLineNumber;
+    return lines[++nextLineNumber];
 }
 
 let tokenSource = null;

--- a/tests/custom_format.gpl
+++ b/tests/custom_format.gpl
@@ -1,0 +1,7 @@
+GIMP Palette
+#Palette Name: Gameboy
+#Colors: 4
+155 188 15
+139 172  15	Row 2
+ 48  98 48 
+ 15 56  15	Row 4

--- a/tests/index.js
+++ b/tests/index.js
@@ -6,6 +6,7 @@ import { parseFileSync } from '../lib/index';
 
 const TEST_OLD_FORMAT = path.join(__dirname, 'old_format.gpl');
 const TEST_NEW_FORMAT = path.join(__dirname, 'new_format.gpl');
+const TEST_CUSTOM_FORMAT = path.join(__dirname, 'custom_format.gpl');
 const TEST_MISSING_HEADER = path.join(__dirname, 'missing_header.gpl');
 
 test('Old format', t => {
@@ -57,6 +58,35 @@ test('New format', t => {
             g: 98,
             b: 48,
             name: 'Row 3'
+        },{
+            r: 15,
+            g: 56,
+            b: 15,
+            name: 'Row 4'
+        }]
+    });
+});
+
+test('Custom format', t => {
+    const parsedData = parseFileSync(TEST_CUSTOM_FORMAT);
+    t.deepEqual(parsedData, {
+        name: 'custom_format.gpl',
+        columns: 0,
+        colors: [{
+            r: 155,
+            g: 188,
+            b: 15,
+            name: 'Untitled'
+        },{
+            r: 139,
+            g: 172,
+            b: 15,
+            name: 'Row 2'
+        },{
+            r: 48,
+            g: 98,
+            b: 48,
+            name: 'Untitled'
         },{
             r: 15,
             g: 56,


### PR DESCRIPTION
Added a check for custom description lines, as I ran into problems when using .gpl files from e.g. https://lospec.com/palette-list
They don't have a single `#` right before the colors, but `#Colors: X` so it failed to parse those files.
Also added a `.gitignore` file and fixed `palette.name` previously including a new line (`\r`) at the end.